### PR TITLE
Add guard on writing H

### DIFF
--- a/src/tb_hamiltonian/hamiltonian.py
+++ b/src/tb_hamiltonian/hamiltonian.py
@@ -196,6 +196,7 @@ class TBHamiltonian:
         self,
         path: Path = Path("output/example"),
         filename: str = "TG_hr.dat",
+        use_mpi=False,
     ) -> None:
         """Write the Hamiltonian to a file.
 
@@ -205,9 +206,25 @@ class TBHamiltonian:
             Path to the directory where the Hamiltonian will be written.
         `filename` : `str`, optional
             Name of the file where the Hamiltonian will be written.
+        `use_mpi` : `bool`, optional
+            Whether to use the MPI parallelization.
         """
         non_zero_elements = sum(H.count_nonzero() for H in self)
         system_label = self.structure.info.get("label", self.structure.symbols)
+
+        if use_mpi:
+            from mpi4py import MPI
+
+            comm = MPI.COMM_WORLD
+            rank = comm.Get_rank()
+        else:
+            rank = 0
+
+        if rank != 0:
+            return
+
+        if self.debug:
+            print("writing Hamiltonian to file...")
 
         with (path / filename).open("w") as file:
             # write banner

--- a/test.ipynb
+++ b/test.ipynb
@@ -28,6 +28,9 @@
     "\n",
     "import numpy as np\n",
     "\n",
+    "debug = False\n",
+    "use_mpi = True\n",
+    "\n",
     "nn = 1  # number of nearest neighbors | don't use 0!\n",
     "\n",
     "workdir = Path(\"examples/BLG/AB/rectangular\")\n",
@@ -94,6 +97,7 @@
     "    distances=(0.0, 1.425, 2.468, 2.850),\n",
     "    hopping_parameters=(0.0, -2.7, 0.0, -0.27),\n",
     "    interlayer_coupling=0.33,\n",
+    "    debug=debug,\n",
     ")\n",
     "\n",
     "H.build()"
@@ -173,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "H.write_to_file(path)"
+    "# H.write_to_file(path, use_mpi=use_mpi)"
    ]
   },
   {
@@ -228,7 +232,7 @@
     "#     points_per_segment=100,\n",
     "#     use_sparse_solver=False,\n",
     "#     sparse_solver_params={\"k\": 3, \"sigma\": 1e-8},\n",
-    "#     use_mpi=False,\n",
+    "#     use_mpi=use_mpi,\n",
     "#     savefig_path=path / \"bands.png\",\n",
     "# )"
    ]

--- a/test.py
+++ b/test.py
@@ -8,6 +8,9 @@ from tb_hamiltonian.utils import get_structure
 
 sys.tracebacklimit = None
 
+debug = False
+use_mpi = False
+
 nn = 1  # number of nearest neighbors | don't use 0!
 
 workdir = Path("examples/BLG/AB/rectangular")
@@ -46,6 +49,7 @@ H = TBHamiltonian(
     distances=(0.0, 1.425, 2.468, 2.850),
     hopping_parameters=(0.0, -2.7, 0.0, -0.27),
     interlayer_coupling=0.33,
+    debug=debug,
 )
 
 H.build()
@@ -73,7 +77,7 @@ path.mkdir(parents=True, exist_ok=True)
 
 # Write H to file
 
-H.write_to_file(path)
+H.write_to_file(path, use_mpi=use_mpi)
 
 # Plotting
 
@@ -89,6 +93,6 @@ H.plot_bands(
     points_per_segment=20,
     use_sparse_solver=False,
     sparse_solver_params={"k": H.natoms - 2, "sigma": 1e-8},
-    use_mpi=False,
+    use_mpi=use_mpi,
     savefig_path=path / "bands.png",
 )


### PR DESCRIPTION
This PR adds a guard on the `write_to_file` method of `TBHamiltonian` to ensure when using MPI that only rank 0 writes H to file.

Addresses issue #4.